### PR TITLE
fix(playlist): 修复专辑收藏跳转与详情页接口错误

### DIFF
--- a/app/src/main/java/com/lin0721/linmusic/MelodiaNavHost.kt
+++ b/app/src/main/java/com/lin0721/linmusic/MelodiaNavHost.kt
@@ -102,6 +102,7 @@ fun MelodiaNavHost(
                 com.lin0721.linmusic.feature.library.ui.LibraryScreen(
                     onPlaylistClick = { id -> onNavigateToPlaylist(id, false) },
                     onArtistClick = onNavigateToArtist,
+                    onAlbumClick = { id -> onNavigateToPlaylist(id, true) },
                     onBack = onBack,
                     onOpenSidebar = onOpenSidebar,
                     onLoginScreenVisibilityChanged = onLoginScreenVisibilityChanged

--- a/app/src/main/java/com/lin0721/linmusic/feature/library/ui/LibraryScreen.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/library/ui/LibraryScreen.kt
@@ -65,6 +65,7 @@ import com.lin0721.linmusic.core.auth.UserProfile
 fun LibraryScreen(
     onPlaylistClick: (Long) -> Unit,
     onArtistClick: (Long) -> Unit,
+    onAlbumClick: (Long) -> Unit,
     onBack: () -> Unit,
     onOpenSidebar: () -> Unit = {},
     onLoginScreenVisibilityChanged: (Boolean) -> Unit = {}
@@ -357,7 +358,7 @@ fun LibraryScreen(
                                                     } else if (item.type == LibraryItemType.ARTIST) {
                                                         onArtistClick(item.id.toLong())
                                                     } else {
-                                                        com.lin0721.linmusic.core.ui.components.ToastManager.showToast("已收藏的专辑: ${item.title}")
+                                                        onAlbumClick(item.id.toLong())
                                                     }
                                                 }
                                             )
@@ -383,7 +384,7 @@ fun LibraryScreen(
                                             } else if (item.type == LibraryItemType.ARTIST) {
                                                 onArtistClick(item.id.toLong())
                                             } else {
-                                                com.lin0721.linmusic.core.ui.components.ToastManager.showToast("已收藏的专辑: ${item.title}")
+                                                onAlbumClick(item.id.toLong())
                                             }
                                         },
                                         onLongClick = {

--- a/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistApi.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistApi.kt
@@ -36,6 +36,13 @@ interface PlaylistApi {
         @Path("op") op: String,
         @Body body: PlaylistSubscribeRequest
     ): PlaylistSubscribeResponse
+
+    // ================== 专辑收藏操作 (收藏/取消收藏) ==================
+    @POST("/weapi/album/{op}")
+    suspend fun subscribeAlbum(
+        @Path("op") op: String,
+        @Body body: AlbumSubscribeRequest
+    ): AlbumSubscribeResponse
 }
 
 // ======================= 歌单详情 =======================
@@ -84,6 +91,21 @@ data class PlaylistSubscribeRequest(
 
 @Serializable
 data class PlaylistSubscribeResponse(
+    val code: Int = 0,
+    val message: String? = null
+) {
+    val isSuccess: Boolean get() = code == 200
+}
+
+// ======================= 收藏与取消收藏专辑 DTO =======================
+
+@Serializable
+data class AlbumSubscribeRequest(
+    val id: Long
+)
+
+@Serializable
+data class AlbumSubscribeResponse(
     val code: Int = 0,
     val message: String? = null
 ) {

--- a/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistRepository.kt
@@ -15,6 +15,9 @@ interface PlaylistRepository {
     // 收藏/取消收藏歌单
     fun subscribePlaylist(playlistId: Long, subscribe: Boolean): Flow<Result<Unit>>
 
+    // 收藏/取消收藏专辑
+    fun subscribeAlbum(albumId: Long, subscribe: Boolean): Flow<Result<Unit>>
+
     // 歌单歌曲添加/删除操作
     fun manipulatePlaylistTracks(op: String, playlistId: Long, trackId: Long): Flow<Result<Unit>>
 }

--- a/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistRepositoryImpl.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/playlist/data/PlaylistRepositoryImpl.kt
@@ -51,6 +51,19 @@ class PlaylistRepositoryImpl(
         transform = { Unit }
     )
 
+    override fun subscribeAlbum(albumId: Long, subscribe: Boolean): Flow<Result<Unit>> = apiFlow(
+        request = {
+            apiService.subscribeAlbum(
+                op = if (subscribe) "sub" else "unsub",
+                body = AlbumSubscribeRequest(id = albumId)
+            )
+        },
+        isSuccess = { it.isSuccess },
+        code = { it.code },
+        msg = { it.message },
+        transform = { Unit }
+    )
+
     override fun manipulatePlaylistTracks(op: String, playlistId: Long, trackId: Long): Flow<Result<Unit>> = apiFlow(
         request = {
             apiService.manipulatePlaylistTracks(

--- a/app/src/main/java/com/lin0721/linmusic/feature/playlist/ui/PlaylistScreen.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/playlist/ui/PlaylistScreen.kt
@@ -217,12 +217,13 @@ fun PlaylistScreen(
 
                     val firstArtist = playlist.tracks.firstOrNull()?.ar?.firstOrNull()
                     val artistName = firstArtist?.name ?: "未知歌手"
+                    val resourceLabel = if (isAlbum) "专辑" else "歌单"
 
                     val menuItems = listOf(
                         PlaylistMenuItem(
                             icon = if (successState.isSubscribed) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                            title = if (successState.isSubscribed) "取消收藏歌单" else "收藏歌单",
-                            subtitle = "收藏歌单到我的音乐库"
+                            title = if (successState.isSubscribed) "取消收藏$resourceLabel" else "收藏$resourceLabel",
+                            subtitle = "收藏${resourceLabel}到我的音乐库"
                         ) {
                             showMoreMenuSheet = false
                             if (userProfile == null) {

--- a/app/src/main/java/com/lin0721/linmusic/feature/playlist/ui/PlaylistViewModel.kt
+++ b/app/src/main/java/com/lin0721/linmusic/feature/playlist/ui/PlaylistViewModel.kt
@@ -144,11 +144,30 @@ class PlaylistViewModel(
                         } else {
                             allRecommendedTracks = emptyList()
                         }
+                        // 专辑详情接口不下发收藏状态，需额外核对已收藏专辑列表
+                        if (isAlbum) {
+                            checkAlbumSubscribed(detail.id)
+                        }
                     },
                     onFailure = { error ->
                         _uiState.value = PlaylistUiState.Error(error.toUserMessage(resourceProvider))
                     }
                 )
+            }
+        }
+    }
+
+    private fun checkAlbumSubscribed(albumId: Long) {
+        viewModelScope.launch {
+            libraryRepository.getCollectedAlbums().collect { result ->
+                result.onSuccess { albums ->
+                    val subscribed = albums.any { it.id == albumId }
+                    _uiState.update { state ->
+                        if (state is PlaylistUiState.Success && state.playlist.id == albumId) {
+                            state.copy(isSubscribed = subscribed)
+                        } else state
+                    }
+                }
             }
         }
     }
@@ -293,15 +312,21 @@ class PlaylistViewModel(
 
     fun toggleSubscribePlaylist() {
         val successState = _uiState.value as? PlaylistUiState.Success ?: return
-        val playlistId = successState.playlist.id
+        val id = successState.playlist.id
         val targetSubscribe = !successState.isSubscribed
+        val resourceLabel = if (isAlbumMode) "专辑" else "歌单"
         viewModelScope.launch {
-            playlistRepository.subscribePlaylist(playlistId, targetSubscribe).collect { result ->
+            val flow = if (isAlbumMode) {
+                playlistRepository.subscribeAlbum(id, targetSubscribe)
+            } else {
+                playlistRepository.subscribePlaylist(id, targetSubscribe)
+            }
+            flow.collect { result ->
                 result.onSuccess {
                     _uiState.update { state ->
                         if (state is PlaylistUiState.Success) state.copy(isSubscribed = targetSubscribe) else state
                     }
-                    _toastEvent.emit(if (targetSubscribe) "已收藏歌单" else "已取消收藏歌单")
+                    _toastEvent.emit(if (targetSubscribe) "已收藏$resourceLabel" else "已取消收藏$resourceLabel")
                 }.onFailure { e ->
                     _toastEvent.emit(e.toUserMessage(resourceProvider))
                 }
@@ -309,10 +334,13 @@ class PlaylistViewModel(
         }
     }
 
+    // 评论区 threadId：歌单为 A_PL_0_，专辑为 R_AL_3_，二者接口不通用
+    private fun commentThreadId(id: Long): String = if (isAlbumMode) "R_AL_3_$id" else "A_PL_0_$id"
+
     fun loadPlaylistComments(playlistId: Long) {
         viewModelScope.launch {
             _commentsState.value = CommentsState.Loading
-            val threadId = "A_PL_0_$playlistId"
+            val threadId = commentThreadId(playlistId)
             commentRepository.getComments(threadId, limit = 20).collect { result ->
                 result.onSuccess { response ->
                     _commentsState.value = CommentsState.Success(
@@ -339,7 +367,7 @@ class PlaylistViewModel(
             
             val successState = _uiState.value as? PlaylistUiState.Success ?: return@launch
             val playlistId = successState.playlist.id
-            val threadId = "A_PL_0_$playlistId"
+            val threadId = commentThreadId(playlistId)
             val targetLike = !comment.liked
 
             val updatedComments = currentState.comments.map {


### PR DESCRIPTION
## Summary
- 专辑封面点击从提示 Toast 改为真正跳转到专辑详情页（音乐库 - 专辑列表）
- 专辑详情页收藏按钮此前误调歌单收藏接口（把专辑 ID 当歌单 ID），现按专辑分流到专辑专用收藏接口
- 专辑详情页评论 threadId 此前硬编码为歌单类型，现改用专辑类型前缀，评论区恢复正常加载
- 专辑详情接口本身不下发收藏状态，改为加载后核对已收藏专辑列表来确定收藏按钮初始态

## Test plan
- [x] `compileDebugKotlin` 编译通过
- [x] 真机（Pixel 10 Pro XL）验证：从音乐库进入已收藏专辑详情页，收藏图标正确显示已收藏态；评论区正常加载真实评论